### PR TITLE
Fix crash on x64 windows

### DIFF
--- a/olcNoiseMaker.h
+++ b/olcNoiseMaker.h
@@ -229,7 +229,7 @@ private:
 	}
 
 	// Static wrapper for sound card handler
-	static void CALLBACK waveOutProcWrap(HWAVEOUT hWaveOut, UINT uMsg, DWORD dwInstance, DWORD dwParam1, DWORD dwParam2)
+	static void CALLBACK waveOutProcWrap(HWAVEOUT hWaveOut, UINT uMsg, DWORD_PTR dwInstance, DWORD dwParam1, DWORD dwParam2)
 	{
 		((olcNoiseMaker*)dwInstance)->waveOutProc(hWaveOut, uMsg, dwParam1, dwParam2);
 	}


### PR DESCRIPTION
Switch DWORD to DWORD_PTR type for parameter dwInstance in waveOutProcWrap, as using a 32bit value as a pointer on a 64 bit system would result in a crash