### PR TITLE
Update to olcNoiseMaker.h for use in VS2022

### DIFF
--- a/olcNoiseMaker.h
+++ b/olcNoiseMaker.h
@@ -63,6 +63,8 @@
 #include <thread>
 #include <atomic>
 #include <condition_variable>
+#include <mmreg.h>
+#include <mmsystem.h>
 using namespace std;
 
 #include <Windows.h>


### PR DESCRIPTION
Added two includes mmreg.h and mmsystem.h that makes waveFormat, WAVEHDR and HWAVEOUT work again in VS2022.